### PR TITLE
SVCPLAN-1450: Refactor so grafana & mysql configs are in hiera

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,38 @@
+# devcontainer
+
+
+For format details, see https://aka.ms/devcontainer.json. 
+
+For config options, see the README at:
+https://github.com/microsoft/vscode-dev-containers/tree/v0.140.1/containers/puppet
+ 
+``` json
+{
+	"name": "Puppet Development Kit (Community)",
+	"dockerFile": "Dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.profiles.linux": {
+			"bash": {
+				"path": "bash",
+			}
+		}
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"puppet.puppet-vscode",
+		"rebornix.Ruby"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "pdk --version",
+}
+```
+
+
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,23 +1,17 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.140.1/containers/puppet
 {
 	"name": "Puppet Development Kit (Community)",
 	"dockerFile": "Dockerfile",
 
-	// Set *default* container specific settings.json values on container create.
 	"settings": {
-		"terminal.integrated.shell.linux": "/bin/bash"
+		"terminal.integrated.profiles.linux": {
+			"bash": {
+				"path": "bash"
+			}
+		}
 	},
 
-	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"puppet.puppet-vscode",
 		"rebornix.Ruby"
 	]
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "pdk --version",
 }

--- a/.github/workflows/pdk-validate.yml
+++ b/.github/workflows/pdk-validate.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Clone repository"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "Run pdk validate"
         uses: "puppets-epic-show-theatre/action-pdk-validate@v1"
         with:

--- a/.pdkignore
+++ b/.pdkignore
@@ -39,7 +39,6 @@
 /rakelib/
 /.rspec
 /.rubocop.yml
-/.travis.yml
 /.yardopts
 /spec/
 /.vscode/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
 - rubocop-rspec
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: '2.4'
+  TargetRubyVersion: '2.5'
   Include:
   - "**/*.rb"
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -13,21 +13,31 @@ def location_for(place_or_version, fake_version = nil)
   end
 end
 
-ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
-minor_version = ruby_version_segments[0..1].join('.')
-
 group :development do
-  gem "json", '= 2.0.4',                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.3.0',                                         require: false if Gem::Requirement.create(['>= 2.7.0', '< 2.8.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "puppet-module-posix-default-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
-  gem "puppet-module-posix-dev-r#{minor_version}", '~> 1.0',     require: false, platforms: [:ruby]
-  gem "puppet-module-win-default-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-win-dev-r#{minor_version}", '~> 1.0',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "json", '= 2.1.0',                           require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.3.0',                           require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.5.1',                           require: false if Gem::Requirement.create(['>= 3.0.0', '< 3.0.5']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.6.1',                           require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.6.3',                           require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "voxpupuli-puppet-lint-plugins", '~> 4.0',   require: false
+  gem "facterdb", '~> 1.18',                       require: false
+  gem "metadata-json-lint", '>= 2.0.2', '< 4.0.0', require: false
+  gem "puppetlabs_spec_helper", '~> 5.0',          require: false
+  gem "rspec-puppet-facts", '~> 2.0',              require: false
+  gem "codecov", '~> 0.2',                         require: false
+  gem "dependency_checker", '~> 0.2',              require: false
+  gem "parallel_tests", '= 3.12.1',                require: false
+  gem "pry", '~> 0.10',                            require: false
+  gem "simplecov-console", '~> 0.5',               require: false
+  gem "puppet-debugger", '~> 1.0',                 require: false
+  gem "rubocop", '= 1.6.1',                        require: false
+  gem "rubocop-performance", '= 1.9.1',            require: false
+  gem "rubocop-rspec", '= 2.0.1',                  require: false
+  gem "rb-readline", '= 0.5.5',                    require: false, platforms: [:mswin, :mingw, :x64_mingw]
 end
 group :system_tests do
-  gem "puppet-module-posix-system-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
-  gem "puppet-module-win-system-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet_litmus", '< 1.0.0', require: false, platforms: [:ruby, :x64_mingw]
+  gem "serverspec", '~> 2.41',    require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -7,9 +7,9 @@
 ### Classes
 
 * [`profile_metrics_alerting`](#profile_metrics_alerting): Configure metrics grafana services
-* [`profile_metrics_alerting::alert_cycle`](#profile_metrics_alertingalert_cycle): Pauses and starts (cycles) alerts on a schedule
-* [`profile_metrics_alerting::ssh`](#profile_metrics_alertingssh): Allow ssh between metrics servers
-* [`profile_metrics_alerting::tools`](#profile_metrics_alertingtools): Install and configure grafana_tools
+* [`profile_metrics_alerting::alert_cycle`](#profile_metrics_alerting--alert_cycle): Pauses and starts (cycles) alerts on a schedule
+* [`profile_metrics_alerting::ssh`](#profile_metrics_alerting--ssh): Allow ssh between metrics servers
+* [`profile_metrics_alerting::tools`](#profile_metrics_alerting--tools): Install and configure grafana_tools
 
 ## Classes
 
@@ -29,57 +29,29 @@ include profile_metrics_alerting
 
 The following parameters are available in the `profile_metrics_alerting` class:
 
-* [`cilogon_client_id`](#cilogon_client_id)
-* [`cilogon_client_secret`](#cilogon_client_secret)
-* [`db_name`](#db_name)
-* [`db_passwd`](#db_passwd)
-* [`db_user`](#db_user)
-* [`grafana_server_root_url`](#grafana_server_root_url)
-* [`grafana_version`](#grafana_version)
+* [`db_name`](#-profile_metrics_alerting--db_name)
+* [`db_passwd`](#-profile_metrics_alerting--db_passwd)
+* [`db_user`](#-profile_metrics_alerting--db_user)
 
-##### <a name="cilogon_client_id"></a>`cilogon_client_id`
-
-Data type: `String`
-
-CILogon OIDC client ID
-
-##### <a name="cilogon_client_secret"></a>`cilogon_client_secret`
-
-Data type: `String`
-
-CILogon OIDC client secret
-
-##### <a name="db_name"></a>`db_name`
+##### <a name="-profile_metrics_alerting--db_name"></a>`db_name`
 
 Data type: `String`
 
 Name of MySQL database used by grafana
 
-##### <a name="db_passwd"></a>`db_passwd`
+##### <a name="-profile_metrics_alerting--db_passwd"></a>`db_passwd`
 
 Data type: `String`
 
 Password of MySQL database user for grafana
 
-##### <a name="db_user"></a>`db_user`
+##### <a name="-profile_metrics_alerting--db_user"></a>`db_user`
 
 Data type: `String`
 
 Username of MySQL database user for grafana
 
-##### <a name="grafana_server_root_url"></a>`grafana_server_root_url`
-
-Data type: `String`
-
-root_url for grafana server including protocol
-
-##### <a name="grafana_version"></a>`grafana_version`
-
-Data type: `String`
-
-optional version of grafana installed
-
-### <a name="profile_metrics_alertingalert_cycle"></a>`profile_metrics_alerting::alert_cycle`
+### <a name="profile_metrics_alerting--alert_cycle"></a>`profile_metrics_alerting::alert_cycle`
 
 Pauses and starts (cycles) alerts on a schedule
 
@@ -87,30 +59,30 @@ Pauses and starts (cycles) alerts on a schedule
 
 The following parameters are available in the `profile_metrics_alerting::alert_cycle` class:
 
-* [`crons`](#crons)
-* [`enable_cycle_alerts`](#enable_cycle_alerts)
-* [`script_path`](#script_path)
+* [`crons`](#-profile_metrics_alerting--alert_cycle--crons)
+* [`enable_cycle_alerts`](#-profile_metrics_alerting--alert_cycle--enable_cycle_alerts)
+* [`script_path`](#-profile_metrics_alerting--alert_cycle--script_path)
 
-##### <a name="crons"></a>`crons`
+##### <a name="-profile_metrics_alerting--alert_cycle--crons"></a>`crons`
 
 Data type: `Hash`
 
 Hash of CRON entries for pausing/starting alerts.
 For the command key, the path to a alert_toggle script should be omitted
 
-##### <a name="enable_cycle_alerts"></a>`enable_cycle_alerts`
+##### <a name="-profile_metrics_alerting--alert_cycle--enable_cycle_alerts"></a>`enable_cycle_alerts`
 
 Data type: `Boolean`
 
 Enable or disable the cycling of alerts
 
-##### <a name="script_path"></a>`script_path`
+##### <a name="-profile_metrics_alerting--alert_cycle--script_path"></a>`script_path`
 
 Data type: `String`
 
 Path to the alert_toggle.sh script
 
-### <a name="profile_metrics_alertingssh"></a>`profile_metrics_alerting::ssh`
+### <a name="profile_metrics_alerting--ssh"></a>`profile_metrics_alerting::ssh`
 
 Allow ssh between metrics servers
 
@@ -126,36 +98,36 @@ include profile_metrics_alerting::ssh
 
 The following parameters are available in the `profile_metrics_alerting::ssh` class:
 
-* [`metrics_node_ips`](#metrics_node_ips)
-* [`sshkey_pub`](#sshkey_pub)
-* [`sshkey_priv`](#sshkey_priv)
-* [`sshkey_type`](#sshkey_type)
+* [`metrics_node_ips`](#-profile_metrics_alerting--ssh--metrics_node_ips)
+* [`sshkey_pub`](#-profile_metrics_alerting--ssh--sshkey_pub)
+* [`sshkey_priv`](#-profile_metrics_alerting--ssh--sshkey_priv)
+* [`sshkey_type`](#-profile_metrics_alerting--ssh--sshkey_type)
 
-##### <a name="metrics_node_ips"></a>`metrics_node_ips`
+##### <a name="-profile_metrics_alerting--ssh--metrics_node_ips"></a>`metrics_node_ips`
 
 Data type: `Array[String]`
 
 List of metrics node ip addresses that need sshd access
 
-##### <a name="sshkey_pub"></a>`sshkey_pub`
+##### <a name="-profile_metrics_alerting--ssh--sshkey_pub"></a>`sshkey_pub`
 
 Data type: `String`
 
 Public part of root's sshkey.
 
-##### <a name="sshkey_priv"></a>`sshkey_priv`
+##### <a name="-profile_metrics_alerting--ssh--sshkey_priv"></a>`sshkey_priv`
 
 Data type: `String`
 
 Private part of root's sshkey.
 
-##### <a name="sshkey_type"></a>`sshkey_type`
+##### <a name="-profile_metrics_alerting--ssh--sshkey_type"></a>`sshkey_type`
 
 Data type: `String`
 
 OPTIONAL - defaults to "rsa"
 
-### <a name="profile_metrics_alertingtools"></a>`profile_metrics_alerting::tools`
+### <a name="profile_metrics_alerting--tools"></a>`profile_metrics_alerting::tools`
 
 See https://github.com/jdmaloney/grafana_tools
 
@@ -171,142 +143,156 @@ include profile_metrics_alerting::tools
 
 The following parameters are available in the `profile_metrics_alerting::tools` class:
 
-* [`backup_and_sync_cron_hour`](#backup_and_sync_cron_hour)
-* [`backup_and_sync_cron_minute`](#backup_and_sync_cron_minute)
-* [`backup_and_sync_cron_month`](#backup_and_sync_cron_month)
-* [`backup_and_sync_cron_monthday`](#backup_and_sync_cron_monthday)
-* [`backup_and_sync_cron_weekday`](#backup_and_sync_cron_weekday)
-* [`backup_and_sync_destination_host`](#backup_and_sync_destination_host)
-* [`backup_and_sync_destination_path`](#backup_and_sync_destination_path)
-* [`backup_and_sync_enable`](#backup_and_sync_enable)
-* [`grafana_admin_password`](#grafana_admin_password)
-* [`grafana_admin_user`](#grafana_admin_user)
-* [`ldap_sync_base_dir`](#ldap_sync_base_dir)
-* [`ldap_sync_cron_hour`](#ldap_sync_cron_hour)
-* [`ldap_sync_cron_minute`](#ldap_sync_cron_minute)
-* [`ldap_sync_cron_month`](#ldap_sync_cron_month)
-* [`ldap_sync_cron_monthday`](#ldap_sync_cron_monthday)
-* [`ldap_sync_cron_weekday`](#ldap_sync_cron_weekday)
-* [`ldap_sync_enable`](#ldap_sync_enable)
-* [`ldap_sync_groups`](#ldap_sync_groups)
-* [`whitelabel_subtitle`](#whitelabel_subtitle)
-* [`whitelabel_title`](#whitelabel_title)
+* [`backup_and_sync_cron_hour`](#-profile_metrics_alerting--tools--backup_and_sync_cron_hour)
+* [`backup_and_sync_cron_minute`](#-profile_metrics_alerting--tools--backup_and_sync_cron_minute)
+* [`backup_and_sync_cron_month`](#-profile_metrics_alerting--tools--backup_and_sync_cron_month)
+* [`backup_and_sync_cron_monthday`](#-profile_metrics_alerting--tools--backup_and_sync_cron_monthday)
+* [`backup_and_sync_cron_weekday`](#-profile_metrics_alerting--tools--backup_and_sync_cron_weekday)
+* [`backup_and_sync_destination_host`](#-profile_metrics_alerting--tools--backup_and_sync_destination_host)
+* [`backup_and_sync_destination_path`](#-profile_metrics_alerting--tools--backup_and_sync_destination_path)
+* [`backup_and_sync_enable`](#-profile_metrics_alerting--tools--backup_and_sync_enable)
+* [`grafana_admin_password`](#-profile_metrics_alerting--tools--grafana_admin_password)
+* [`grafana_admin_user`](#-profile_metrics_alerting--tools--grafana_admin_user)
+* [`ldap_sync_base_dir`](#-profile_metrics_alerting--tools--ldap_sync_base_dir)
+* [`ldap_sync_cron_hour`](#-profile_metrics_alerting--tools--ldap_sync_cron_hour)
+* [`ldap_sync_cron_minute`](#-profile_metrics_alerting--tools--ldap_sync_cron_minute)
+* [`ldap_sync_cron_month`](#-profile_metrics_alerting--tools--ldap_sync_cron_month)
+* [`ldap_sync_cron_monthday`](#-profile_metrics_alerting--tools--ldap_sync_cron_monthday)
+* [`ldap_sync_cron_weekday`](#-profile_metrics_alerting--tools--ldap_sync_cron_weekday)
+* [`ldap_sync_enable`](#-profile_metrics_alerting--tools--ldap_sync_enable)
+* [`ldap_sync_groups`](#-profile_metrics_alerting--tools--ldap_sync_groups)
+* [`ldap_sync_group_search_base`](#-profile_metrics_alerting--tools--ldap_sync_group_search_base)
+* [`ldap_sync_user_search_base`](#-profile_metrics_alerting--tools--ldap_sync_user_search_base)
+* [`whitelabel_subtitle`](#-profile_metrics_alerting--tools--whitelabel_subtitle)
+* [`whitelabel_title`](#-profile_metrics_alerting--tools--whitelabel_title)
 
-##### <a name="backup_and_sync_cron_hour"></a>`backup_and_sync_cron_hour`
+##### <a name="-profile_metrics_alerting--tools--backup_and_sync_cron_hour"></a>`backup_and_sync_cron_hour`
 
 Data type: `String`
 
 hour that the backup_and_sync cron should run
 
-##### <a name="backup_and_sync_cron_minute"></a>`backup_and_sync_cron_minute`
+##### <a name="-profile_metrics_alerting--tools--backup_and_sync_cron_minute"></a>`backup_and_sync_cron_minute`
 
 Data type: `String`
 
 minute that the backup_and_sync cron should run
 
-##### <a name="backup_and_sync_cron_month"></a>`backup_and_sync_cron_month`
+##### <a name="-profile_metrics_alerting--tools--backup_and_sync_cron_month"></a>`backup_and_sync_cron_month`
 
 Data type: `String`
 
 month that the backup_and_sync cron should run
 
-##### <a name="backup_and_sync_cron_monthday"></a>`backup_and_sync_cron_monthday`
+##### <a name="-profile_metrics_alerting--tools--backup_and_sync_cron_monthday"></a>`backup_and_sync_cron_monthday`
 
 Data type: `String`
 
 monthday that the backup_and_sync cron should run
 
-##### <a name="backup_and_sync_cron_weekday"></a>`backup_and_sync_cron_weekday`
+##### <a name="-profile_metrics_alerting--tools--backup_and_sync_cron_weekday"></a>`backup_and_sync_cron_weekday`
 
 Data type: `String`
 
 weekday that the backup_and_sync cron should run
 
-##### <a name="backup_and_sync_destination_host"></a>`backup_and_sync_destination_host`
+##### <a name="-profile_metrics_alerting--tools--backup_and_sync_destination_host"></a>`backup_and_sync_destination_host`
 
 Data type: `String`
 
 Host were backups are synced to
 
-##### <a name="backup_and_sync_destination_path"></a>`backup_and_sync_destination_path`
+##### <a name="-profile_metrics_alerting--tools--backup_and_sync_destination_path"></a>`backup_and_sync_destination_path`
 
 Data type: `String`
 
 Path on destination host where backups are synced to
 
-##### <a name="backup_and_sync_enable"></a>`backup_and_sync_enable`
+##### <a name="-profile_metrics_alerting--tools--backup_and_sync_enable"></a>`backup_and_sync_enable`
 
 Data type: `Boolean`
 
 Whether or not backup_and_sync script is automated
 
-##### <a name="grafana_admin_password"></a>`grafana_admin_password`
+##### <a name="-profile_metrics_alerting--tools--grafana_admin_password"></a>`grafana_admin_password`
 
 Data type: `String`
 
 Password of Grafana admin user
 
-##### <a name="grafana_admin_user"></a>`grafana_admin_user`
+##### <a name="-profile_metrics_alerting--tools--grafana_admin_user"></a>`grafana_admin_user`
 
 Data type: `String`
 
 Username of Grafana admin user
 
-##### <a name="ldap_sync_base_dir"></a>`ldap_sync_base_dir`
+##### <a name="-profile_metrics_alerting--tools--ldap_sync_base_dir"></a>`ldap_sync_base_dir`
 
 Data type: `String`
 
 Base directory used by ldap sync
 
-##### <a name="ldap_sync_cron_hour"></a>`ldap_sync_cron_hour`
+##### <a name="-profile_metrics_alerting--tools--ldap_sync_cron_hour"></a>`ldap_sync_cron_hour`
 
 Data type: `String`
 
 hour that the ldap_sync cron should run
 
-##### <a name="ldap_sync_cron_minute"></a>`ldap_sync_cron_minute`
+##### <a name="-profile_metrics_alerting--tools--ldap_sync_cron_minute"></a>`ldap_sync_cron_minute`
 
 Data type: `String`
 
 minute that the ldap_sync cron should run
 
-##### <a name="ldap_sync_cron_month"></a>`ldap_sync_cron_month`
+##### <a name="-profile_metrics_alerting--tools--ldap_sync_cron_month"></a>`ldap_sync_cron_month`
 
 Data type: `String`
 
 month that the ldap_sync cron should run
 
-##### <a name="ldap_sync_cron_monthday"></a>`ldap_sync_cron_monthday`
+##### <a name="-profile_metrics_alerting--tools--ldap_sync_cron_monthday"></a>`ldap_sync_cron_monthday`
 
 Data type: `String`
 
 monthday that the ldap_sync cron should run
 
-##### <a name="ldap_sync_cron_weekday"></a>`ldap_sync_cron_weekday`
+##### <a name="-profile_metrics_alerting--tools--ldap_sync_cron_weekday"></a>`ldap_sync_cron_weekday`
 
 Data type: `String`
 
 weekday that the ldap_sync cron should run
 
-##### <a name="ldap_sync_enable"></a>`ldap_sync_enable`
+##### <a name="-profile_metrics_alerting--tools--ldap_sync_enable"></a>`ldap_sync_enable`
 
 Data type: `Boolean`
 
 Whether or not ldap_sync script is automated
 
-##### <a name="ldap_sync_groups"></a>`ldap_sync_groups`
+##### <a name="-profile_metrics_alerting--tools--ldap_sync_groups"></a>`ldap_sync_groups`
 
 Data type: `Array[String]`
 
 List of ldap groups to sync to Grafana
 
-##### <a name="whitelabel_subtitle"></a>`whitelabel_subtitle`
+##### <a name="-profile_metrics_alerting--tools--ldap_sync_group_search_base"></a>`ldap_sync_group_search_base`
+
+Data type: `String`
+
+Base filter for ldap group search
+
+##### <a name="-profile_metrics_alerting--tools--ldap_sync_user_search_base"></a>`ldap_sync_user_search_base`
+
+Data type: `String`
+
+Base filter for ldap user search
+
+##### <a name="-profile_metrics_alerting--tools--whitelabel_subtitle"></a>`whitelabel_subtitle`
 
 Data type: `String`
 
 Custom subtitle applied to Grafana instance
 
-##### <a name="whitelabel_title"></a>`whitelabel_title`
+##### <a name="-profile_metrics_alerting--tools--whitelabel_title"></a>`whitelabel_title`
 
 Data type: `String`
 

--- a/Rakefile
+++ b/Rakefile
@@ -43,6 +43,7 @@ end
 
 PuppetLint.configuration.send('disable_relative')
 
+
 if Bundler.rubygems.find_name('github_changelog_generator').any?
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
     raise "Set CHANGELOG_GITHUB_TOKEN environment variable eg 'export CHANGELOG_GITHUB_TOKEN=valid_token_here'" if Rake.application.top_level_tasks.include? "changelog" and ENV['CHANGELOG_GITHUB_TOKEN'].nil?

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -35,5 +35,7 @@ profile_metrics_alerting::tools::ldap_sync_cron_monthday: "*"
 profile_metrics_alerting::tools::ldap_sync_cron_weekday: "*"
 profile_metrics_alerting::tools::ldap_sync_enable: true
 profile_metrics_alerting::tools::ldap_sync_groups: []
+profile_metrics_alerting::tools::ldap_sync_group_search_base: ""
+profile_metrics_alerting::tools::ldap_sync_user_search_base: ""
 profile_metrics_alerting::tools::whitelabel_subtitle: ""
 profile_metrics_alerting::tools::whitelabel_title: ""

--- a/files/root/grafana_tools/ldap_sync/config
+++ b/files/root/grafana_tools/ldap_sync/config
@@ -1,3 +1,5 @@
 base_dir=""
 admin_password=""
 groups=()
+ldap_user_search_base=""
+ldap_group_search_base=""

--- a/manifests/alert_cycle.pp
+++ b/manifests/alert_cycle.pp
@@ -15,16 +15,14 @@ class profile_metrics_alerting::alert_cycle (
   Boolean $enable_cycle_alerts,
   String $script_path,
 ) {
-
   Cron {
     user => 'root',
   }
 
   if ($enable_cycle_alerts) {
     $crons.each | $k, $v | {
-
       # Create new hash with command set how we want it
-      $override = {'command' => "${script_path} ${v[command]}"}
+      $override = { 'command' => "${script_path} ${v[command]}" }
 
       # Merge hashes, hash on right overrides hash on left when keys are shared in both hashes
       $result = $v + $override
@@ -36,5 +34,4 @@ class profile_metrics_alerting::alert_cycle (
       cron { $k: ensure => absent }
     }
   }
-
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,11 +1,5 @@
 # @summary Configure metrics grafana services
 #
-# @param cilogon_client_id
-#   CILogon OIDC client ID
-#
-# @param cilogon_client_secret
-#   CILogon OIDC client secret
-#
 # @param db_name
 #   Name of MySQL database used by grafana
 #
@@ -15,116 +9,23 @@
 # @param db_user
 #   Username of MySQL database user for grafana
 #
-# @param grafana_server_root_url
-#   root_url for grafana server including protocol
-#
-# @param grafana_version
-#   optional version of grafana installed
-#
 # @example
 #   include profile_metrics_alerting
 class profile_metrics_alerting (
-  String $cilogon_client_id,
-  String $cilogon_client_secret,
   String $db_name,
   String $db_passwd,
   String $db_user,
-  String $grafana_server_root_url,
-  String $grafana_version,
 ) {
-
   # HTTPD PROXY
-  include ::profile_website
+  include profile_website
+
   # MARIADB SERVICE
-  class { 'mysql::server':
-    package_name            => 'mariadb-server',
-    remove_default_accounts => true,
-    restart                 => true,
-  }
-  mysql::db { $db_name:
-    user     => $db_user,
-    password => $db_passwd,
-    host     => 'localhost',
-    charset  => 'utf8mb4',
-    collate  => 'utf8mb4_general_ci',
-  }
+  include profile_mysql_server
 
   # GRAFANA SERVICE
-  class { 'grafana':
-    cfg     => {
-      alerting             => {
-        enabled => true,
-      },
-      analytics            => {
-        reporting => true,
-      },
-      auth                 => {
-        login_maximum_inactive_lifetime_duration => '9h',
-        login_maximum_lifetime_duration          => '7d',
-        disable_login_form                       => true,
-        disable_signout_menu                     => true,
-      },
-      'auth.anonymous'     => {
-        enabled      => true,
-        hide_version => true,
-        org_name     => 'NCSA',
-        org_role     => 'Viewer',
-      },
-      'auth.basic'         => {
-        enabled => true,
-      },
-      'auth.generic_oauth' => {
-        allow_assign_grafana_admin => true,
-        allow_sign_up              => true,
-        api_url                    => 'https://cilogon.org/oauth2/userinfo',
-        auth_url                   => 'https://cilogon.org/authorize',
-        client_id                  => $cilogon_client_id,
-        client_secret              => $cilogon_client_secret,
-        enabled                    => true,
-        login_attribute_path       => 'uid',
-        name                       => 'NCSA CILogon',
-        role_attribute_path        => 'contains(isMemberOf[*], \'ici_monitoring_admin\') && \'Admin\' || \'Viewer\'',
-        scopes                     => 'openid,email,profile,org.cilogon.userinfo',
-        token_url                  => 'https://cilogon.org/oauth2/token',
-      },
-      'auth.ldap'          => {
-#        allow_sign_up => true,
-#        config_file   => '/etc/grafana/ldap.toml',
-        enabled       => false,
-      },
-      database             => {
-        type     => 'mysql',
-        host     => '127.0.0.1:3306',
-        name     => $db_name,
-        user     => $db_user,
-        password => $db_passwd,
-      },
-      explore              => {
-        enabled => false,
-      },
-      live                 => {
-        allowed_origins => '*',
-      },
-      server               => {
-        root_url => $grafana_server_root_url,
-      },
-      smtp                 => {
-        enabled      => true,
-        from_address => "root@${$facts['fqdn']}",
-        from_name    => 'NCSA ICI Alert Engine',
-        host         => 'localhost:25',
-        skip_verify  => true,
-      },
-      users                => {
-        allow_sign_up    => false,
-        allow_org_create => false,
-      },
-    },
-    version => $grafana_version,
-  }
+  include grafana
 
   include profile_metrics_alerting::alert_cycle
   include profile_metrics_alerting::ssh
   include profile_metrics_alerting::tools
-
 }

--- a/manifests/ssh.pp
+++ b/manifests/ssh.pp
@@ -20,7 +20,6 @@ class profile_metrics_alerting::ssh (
   String $sshkey_priv,
   String $sshkey_type,
 ) {
-
   # NEED TO SETUP SOME SSH KEYS USED FOR SYNCING DATA BETWEEN METRICS HOSTS
 
   # Secure sensitive data to prevent it showing in logs
@@ -37,7 +36,7 @@ class profile_metrics_alerting::ssh (
     owner   => root,
     group   => root,
     mode    => '0600',
-    require =>  File[ $sshdir ],
+    require => File[$sshdir],
   }
 
   # Define unique parameters of each resource
@@ -66,7 +65,6 @@ class profile_metrics_alerting::ssh (
     key    => $pubkey,
   }
 
-
   # SSHD CONFIGURATION
 
   $params = {
@@ -77,10 +75,9 @@ class profile_metrics_alerting::ssh (
     'X11Forwarding'         => 'no',
   }
 
-  ::sshd::allow_from{ 'sshd allow root for metrics nodes':
+  ::sshd::allow_from { 'sshd allow root for metrics nodes':
     hostlist                => $metrics_node_ips,
-    users                   => [ 'root' ],
+    users                   => ['root'],
     additional_match_params => $params,
   }
-
 }

--- a/manifests/tools.pp
+++ b/manifests/tools.pp
@@ -40,6 +40,10 @@
 #   Whether or not ldap_sync script is automated
 # @param ldap_sync_groups
 #   List of ldap groups to sync to Grafana
+# @param ldap_sync_group_search_base
+#   Base filter for ldap group search
+# @param ldap_sync_user_search_base
+#   Base filter for ldap user search
 #
 # @param whitelabel_subtitle
 #   Custom subtitle applied to Grafana instance
@@ -67,10 +71,12 @@ class profile_metrics_alerting::tools (
   String $ldap_sync_cron_weekday,
   Boolean $ldap_sync_enable,
   Array[String] $ldap_sync_groups,
+  String $ldap_sync_group_search_base,
+  String $ldap_sync_user_search_base,
+
   String $whitelabel_subtitle,
   String $whitelabel_title,
 ) {
-
   file { '/root/grafana_tools':
     ensure  => directory,
     #notify  => Exec['ensure_grafana_tools_scripts_executable'],
@@ -109,17 +115,17 @@ class profile_metrics_alerting::tools (
   }
   file_line { 'backup_and_sync/config db':
     path  => '/root/grafana_tools/backup_and_sync/config',
-    line  => "db=${::profile_metrics_alerting::db_name}",
+    line  => "db=${profile_metrics_alerting::db_name}",
     match => '^db=.*|^db\s.*',
   }
   file_line { 'backup_and_sync/config db_password':
     path  => '/root/grafana_tools/backup_and_sync/config',
-    line  => "db_password=${::profile_metrics_alerting::db_passwd}",
+    line  => "db_password=${profile_metrics_alerting::db_passwd}",
     match => '^db_password.*',
   }
   file_line { 'backup_and_sync/config db_user':
     path  => '/root/grafana_tools/backup_and_sync/config',
-    line  => "db_user=${::profile_metrics_alerting::db_user}",
+    line  => "db_user=${profile_metrics_alerting::db_user}",
     match => '^db_user.*',
   }
 
@@ -151,6 +157,16 @@ class profile_metrics_alerting::tools (
     path  => '/root/grafana_tools/ldap_sync/config',
     line  => "groups=(${ldap_groups_joined})",
     match => '^groups.*',
+  }
+  file_line { 'ldap_sync/config ldap_group_search_base':
+    path  => '/root/grafana_tools/ldap_sync/config',
+    line  => "ldap_group_search_base=\"${ldap_sync_group_search_base}\"",
+    match => '^ldap_group_search_base.*',
+  }
+  file_line { 'ldap_sync/config ldap_user_search_base':
+    path  => '/root/grafana_tools/ldap_sync/config',
+    line  => "ldap_user_search_base=\"${ldap_sync_user_search_base}\"",
+    match => '^ldap_user_search_base.*',
   }
 
   # white_label/config
@@ -202,5 +218,4 @@ class profile_metrics_alerting::tools (
       ensure => absent,
     }
   }
-
 }

--- a/metadata.json
+++ b/metadata.json
@@ -40,7 +40,7 @@
       "version_requirement": ">= 6.21.0 < 8.0.0"
     }
   ],
-  "pdk-version": "2.2.0",
-  "template-url": "pdk-default#2.2.0",
-  "template-ref": "tags/2.2.0-0-g2381db6"
+  "pdk-version": "2.7.1",
+  "template-url": "pdk-default#2.7.4",
+  "template-ref": "tags/2.7.4-0-g58edf57"
 }


### PR DESCRIPTION
These changes are so that Grafana can be more customized to run in various environments with differing authentication, etc.

See the following for examples of what moves into control repo's hiera:
- https://github.com/ncsa/puppet-profile_metrics_alerting/tree/wglick/SVCPLAN-1450/refactor_grafana_and_mysql_configs#configuration
- https://git.ncsa.illinois.edu/ici/asd/asd-pup-control/-/commit/15f5955ad55f6133fa5a89644dcc28a3d0d350be (where all secrets are now encrypted)

This is being tested on `metrics-test`.