### PR TITLE
SVCPLAN-1674: Configure grafana_tools backups with ncsa/profile_backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ scripts to do one of the following:
 
 ## Dependencies
 
+- [ncsa/profile_backup](https://github.com/ncsa/puppet-profile_backup)
 - [ncsa/profile_mysql_server](https://github.com/ncsa/puppet-profile_mysql_server)
 - [ncsa/sshd](https://github.com/ncsa/puppet-sshd)
 - [puppet/grafana](https://forge.puppet.com/modules/puppet/grafana)

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -8,6 +8,7 @@
 
 * [`profile_metrics_alerting`](#profile_metrics_alerting): Configure metrics grafana services
 * [`profile_metrics_alerting::alert_cycle`](#profile_metrics_alerting--alert_cycle): Pauses and starts (cycles) alerts on a schedule
+* [`profile_metrics_alerting::backup`](#profile_metrics_alerting--backup): Configure Grafana tools backups
 * [`profile_metrics_alerting::ssh`](#profile_metrics_alerting--ssh): Allow ssh between metrics servers
 * [`profile_metrics_alerting::tools`](#profile_metrics_alerting--tools): Install and configure grafana_tools
 
@@ -81,6 +82,18 @@ Enable or disable the cycling of alerts
 Data type: `String`
 
 Path to the alert_toggle.sh script
+
+### <a name="profile_metrics_alerting--backup"></a>`profile_metrics_alerting::backup`
+
+Configure Grafana tools backups
+
+#### Examples
+
+##### 
+
+```puppet
+include profile_metrics_alerting::backup
+```
 
 ### <a name="profile_metrics_alerting--ssh"></a>`profile_metrics_alerting::ssh`
 

--- a/files/root/grafana_tools/backup_and_sync/backup_grafana.sh
+++ b/files/root/grafana_tools/backup_and_sync/backup_grafana.sh
@@ -6,17 +6,19 @@ pushd $(dirname "$0") > /dev/null
 source ./config
 
 ## Get Grafana backing DB type
-db_type=$(grep "^type = " /etc/grafana/grafana.ini | cut -d' '- f 3)
+db_type=$(grep "^type = " /etc/grafana/grafana.ini | cut -d' ' -f 3)
 
 if [ "${db_type}" == "sqlite3" ]; then
-	systemctl stop grafana-server
+	backup_file_name=grafana_backup_$(date +$Y_%m_%d_%H_%M_%S)
 	data_path=$(grep "data = " /etc/grafana/grafana.ini | cut -d' ' -f 3)
-	scp ${data_path}/grafana.db ${destination_host}:/${destination_path}/
+	systemctl stop grafana-server
+        cp -p ${data_path}/grafana.db /tmp/${backup_file_name}
+	#scp ${data_path}/grafana.db ${destination_host}:/${destination_path}/
 	systemctl start grafana-server
 elif [ "${db_type}" == "mysql" ]; then
 	backup_file_name=grafana_backup_$(date +$Y_%m_%d_%H_%M_%S)
 	mysqldump -u ${db_user} -p${db_password} ${db} > /tmp/${backup_file_name}
-	scp /tmp/${backup_file_name} ${destination_host}:/${destination_path}/
+	#scp /tmp/${backup_file_name} ${destination_host}:/${destination_path}/
 elif [ "${db_type}" == "postgres" ]; then
 	echo "Postgres backend not currently supported"
 	exit 1

--- a/files/root/grafana_tools/backup_and_sync/restore_grafana.sh
+++ b/files/root/grafana_tools/backup_and_sync/restore_grafana.sh
@@ -9,7 +9,7 @@ source_file=$1
 source ./config
 
 ## Get Grafana backing DB type
-db_type=$(grep "^type = " /etc/grafana/grafana.ini | cut -d' '- f 3)
+db_type=$(grep "^type = " /etc/grafana/grafana.ini | cut -d' ' -f 3)
 
 if [ "${db_type}" == "sqlite3" ]; then
 	systemctl stop grafana-server

--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -1,0 +1,22 @@
+# @summary Configure Grafana tools backups
+#
+# @example
+#   include profile_metrics_alerting::backup
+class profile_metrics_alerting::backup {
+  if ( lookup('profile_backup::client::enabled') ) {
+    include profile_backup::client
+
+    profile_backup::client::add_job { 'profile_metrics_alerting':
+      paths             => [
+        '/etc/grafana',
+        '/tmp/grafana_backup_*',
+      ],
+      prehook_commands  => [
+        '/root/grafana_tools/backup_and_sync/backup_grafana.sh',
+      ],
+      posthook_commands => [
+        'find /tmp/grafana_backup_* -mtime +1 -delete',
+      ],
+    }
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,7 @@ class profile_metrics_alerting (
   include grafana
 
   include profile_metrics_alerting::alert_cycle
+  include profile_metrics_alerting::backup
   include profile_metrics_alerting::ssh
   include profile_metrics_alerting::tools
 }

--- a/spec/classes/backup_spec.rb
+++ b/spec/classes/backup_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile_metrics_alerting::backup' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile.with_all_deps }
+    end
+  end
+end


### PR DESCRIPTION
Also:
- Update grafana_tools/backup_and_sync/backup_grafana.sh to only backup, not sync

This is being tested on `metrics02`.

Long term this may not be necessary since most of Grafana's data is stored in the database. The database profile (e.g. `ncsa/profile_mysql`) should take care of backing up its data.